### PR TITLE
Adds new organization-specific locations in the tracon module

### DIFF
--- a/code/modules/busy_space/organizations.dm
+++ b/code/modules/busy_space/organizations.dm
@@ -18,7 +18,6 @@
 		"Glory",
 		"Axiom",
 		"Eternal",
-		"Icarus",
 		"Harmony",
 		"Light",
 		"Discovery",
@@ -44,7 +43,7 @@
 		var/list/star_names = list(
 			"Sol", "Alpha Centauri", "Sirius", "Vega", "Regulus", "Vir", "Algol", "Aldebaran",
 			"Delta Doradus", "Menkar", "Geminga", "Elnath", "Gienah", "Mu Leporis", "Nyx", "Tau Ceti",
-			"Wazn", "Alphard", "Phact", "Altair")
+			"Wazn", "Alphard", "Phact", "Altair", "El", "Eutopia, "Qerr'valis", "Qerrna-Lakirr", "Rarkajar", "the Almach Rim")
 		var/list/destination_types = list("dockyard", "station", "vessel", "waystation", "telecommunications satellite", "spaceport", "distress beacon", "anomaly", "colony", "outpost")
 		while(i)
 			destination_names.Add("a [pick(destination_types)] in [pick(star_names)]")
@@ -79,7 +78,6 @@
 		"NSS Exodus in Nyx",
 		"NCS Northern Star in Vir",
 		"NCS Southern Cross in Vir",
-		"NDV Icarus in Nyx",
 		"NAS Vir Central Command",
 		"a dockyard orbiting Sif",
 		"an asteroid orbiting Kara",
@@ -104,7 +102,7 @@
 	desc = "Hephaestus Industries is the largest supplier of arms, ammunition, and small millitary vehicles in Sol space. \
 	Hephaestus products have a reputation for reliability, and the corporation itself has a noted tendency to stay removed \
 	from corporate politics. They enforce their neutrality with the help of a fairly large asset-protection contingent which \
-	prevents any contracting polities from using their own materiel against them. SolGov itself is one of Hephastus’ largest \
+	prevents any contracting polities from using their own materiel against them. SolGov itself is one of Hephastusâ€™ largest \
 	bulk contractors owing to the above factors."
 	history = ""
 	work = "arms manufacturer"
@@ -113,7 +111,9 @@
 
 	ship_prefixes = list("HTV" = "freight", "HTV" = "munitions resupply")
 	destination_names = list(
-		"a SolGov dockyard on Luna"
+		"a SolGov dockyard on Luna",
+		"a Navy outpost in the Almach Rim",
+		"a Navy outpost on the Moghes border"
 		)
 
 /datum/lore/organization/tsc/vey_med
@@ -124,8 +124,8 @@
 	Despite the suspicion and prejudice leveled at them for their alien origin, Vey-Med has obtained market dominance in \
 	the sale of medical equipment-- from surgical tools to large medical devices to the Oddyseus trauma response mecha \
 	and everything in between. Their equipment tends to be top-of-the-line, most obviously shown by their incredibly \
-	human-like FBP designs. Vey’s rise to stardom came from their introduction of ressurective cloning, although in \
-	recent years they’ve been forced to diversify as their patents expired and NanoTrasen-made medications became \
+	human-like FBP designs. Veyâ€™s rise to stardom came from their introduction of ressurective cloning, although in \
+	recent years theyâ€™ve been forced to diversify as their patents expired and NanoTrasen-made medications became \
 	essential to modern cloning."
 	history = ""
 	work = "medical equipment supplier"
@@ -133,7 +133,11 @@
 	motto = ""
 
 	ship_prefixes = list("VTV" = "transportation", "VMV" = "medical resupply")
-	destination_names = list()
+	destination_names = list(
+		"a research facility in Samsara",
+		"a SDTF near Ue-Orsi",
+		"a sapientarian mission in the Almach Rim"
+		)
 
 /datum/lore/organization/tsc/zeng_hu
 	name = "Zeng-Hu pharmaceuticals"
@@ -141,8 +145,8 @@
 	acronym = "ZH"
 	desc = "Zeng-Hu is an old TSC, based in the Sol system. Until the discovery of Phoron, Zeng-Hu maintained a stranglehold \
 	on the market for medications, and many household names are patentted by Zeng-Hu-- Bicaridyne, Dylovene, Tricordrizine, \
-	and Dexalin all came from a Zeng-Hu medical laboratory. Zeng-Hu’s fortunes have been in decline as Nanotrasen’s near monopoly \
-	on phoron research cuts into their R&D and Vey-Med’s superior medical equipment effectively decimated their own equipment \
+	and Dexalin all came from a Zeng-Hu medical laboratory. Zeng-Huâ€™s fortunes have been in decline as Nanotrasenâ€™s near monopoly \
+	on phoron research cuts into their R&D and Vey-Medâ€™s superior medical equipment effectively decimated their own equipment \
 	interests. The three-way rivalry between these companies for dominance in the medical field is well-known and a matter of \
 	constant economic speculation."
 	history = ""
@@ -160,8 +164,8 @@
 	desc = "Ward-Takahashi focuses on the sale of small consumer electronics, with its computers, communicators, \
 	and even mid-class automobiles a fixture of many households. Less famously, Ward-Takahashi also supplies most \
 	of the AI cores on which vital control systems are mounted, and it is this branch of their industry that has \
-	led to their tertiary interest in the development and sale of high-grade AI systems. Ward-Takahashi’s economies \
-	of scale frequently steal market share from Nanotrasen’s high-price products, leading to a bitter rivalry in the \
+	led to their tertiary interest in the development and sale of high-grade AI systems. Ward-Takahashiâ€™s economies \
+	of scale frequently steal market share from Nanotrasenâ€™s high-price products, leading to a bitter rivalry in the \
 	consumer electronics market."
 	history = ""
 	work = "electronics manufacturer"
@@ -175,10 +179,10 @@
 	name = "Bishop Cybernetics"
 	short_name = "Bishop"
 	acronym = "BC"
-	desc = "Bishop’s focus is on high-class, stylish cybernetics. A favorite among transhumanists (and a bête noire for \
+	desc = "Bishopâ€™s focus is on high-class, stylish cybernetics. A favorite among transhumanists (and a bÃªte noire for \
 	bioconservatives), Bishop manufactures not only prostheses but also brain augmentation, synthetic organ replacements, \
 	and odds and ends like implanted wrist-watches. Their business model tends towards smaller, boutique operations, giving \
-	it a reputation for high price and luxury, with Bishop cyberware often rivalling Vey-Med’s for cost. Bishop’s reputation \
+	it a reputation for high price and luxury, with Bishop cyberware often rivalling Vey-Medâ€™s for cost. Bishopâ€™s reputation \
 	for catering towards the interests of human augmentation enthusiasts instead of positronics have earned it ire from the \
 	Positronic Rights Group and puts it in ideological (but not economic) comptetition with Morpheus Cyberkinetics."
 	history = ""
@@ -289,7 +293,9 @@
 
 
 		)
-	destination_names = list()
+	destination_names = list(
+		"A trade mission in Shelf"
+		)
 
 /datum/lore/organization/tsc/xion
 	name = "Xion Manufacturing Group"


### PR DESCRIPTION
and misc tweaks.

1) Adds systems with lore and trade with SCG to the generic destinations list

2)Gives Vey-Med some Skrell-focused destinations

3)Gives Heph some millitary destinations

4)Gives Morpheus trade with Shelf

5)Strips out the "Icarus" generic ship name and the NDV Icarus Nanotrasen destination. Suddenly this word has a lot of history and I somehow don't see NT naming a ship after the political party they're bitterly opposed to